### PR TITLE
Updating preparForSegue to Swift 3’s version.  Xcode is still generat…

### DIFF
--- a/Photo Map/PhotoMapViewController.swift
+++ b/Photo Map/PhotoMapViewController.swift
@@ -22,14 +22,14 @@ class PhotoMapViewController: UIViewController {
     }
     
 
-    /*
+    
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         // Get the new view controller using segue.destinationViewController.
         // Pass the selected object to the new view controller.
     }
-    */
+    
 
 }


### PR DESCRIPTION
…ing the comment with method signature from Swift 2.3.  Uncommenting this Apple supplied prepareForSegue gives a cryptic error complaining about it doesn’t “override” any super class methods.  Deleting “override” crush the error but creates a confusing situation where prepareForSegue isn’t called on segue.